### PR TITLE
Initialize monorepo for form builder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Server
+PORT=3000
+JWT_SECRET=changeme
+
+# Database
+DATABASE_URL=postgres://user:pass@localhost:5432/forms

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
-# Complete-GPT-test
-testing gpt code space
+# Form Builder Monorepo
+
+This repository contains a simple monorepo setup for a form builder application.
+
+## Packages
+
+- `packages/server` - Node/Express backend with JWT authentication and a sample schema.
+- `packages/web` - React frontend configured with Vite and Tailwind CSS.
+
+## Getting Started
+
+```bash
+npm install # installs all workspace dependencies
+```
+
+### Development
+
+To run the backend:
+
+```bash
+cd packages/server
+npm run dev
+```
+
+To run the frontend:
+
+```bash
+cd packages/web
+npm run dev
+```
+
+Environment variables can be configured using `.env` based on `.env.example`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "form-builder-monorepo",
+  "private": true,
+  "workspaces": [
+    "packages/server",
+    "packages/web"
+  ],
+  "scripts": {
+    "install:all": "npm install --workspaces",
+    "test": "echo \"no tests yet\""
+  }
+}

--- a/packages/server/db/schema.sql
+++ b/packages/server/db/schema.sql
@@ -1,0 +1,39 @@
+-- Users table
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  username VARCHAR(50) UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  role VARCHAR(20) NOT NULL DEFAULT 'user'
+);
+
+-- Forms table
+CREATE TABLE forms (
+  id SERIAL PRIMARY KEY,
+  title VARCHAR(255) NOT NULL,
+  description TEXT,
+  created_by INTEGER REFERENCES users(id)
+);
+
+-- Questions table
+CREATE TABLE questions (
+  id SERIAL PRIMARY KEY,
+  form_id INTEGER REFERENCES forms(id),
+  label TEXT NOT NULL,
+  type VARCHAR(50) NOT NULL
+);
+
+-- Responses table
+CREATE TABLE responses (
+  id SERIAL PRIMARY KEY,
+  form_id INTEGER REFERENCES forms(id),
+  user_id INTEGER REFERENCES users(id),
+  submitted_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Response values
+CREATE TABLE response_values (
+  id SERIAL PRIMARY KEY,
+  response_id INTEGER REFERENCES responses(id),
+  question_id INTEGER REFERENCES questions(id),
+  value TEXT
+);

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -1,0 +1,29 @@
+import express from 'express';
+import jwt from 'jsonwebtoken';
+
+const app = express();
+app.use(express.json());
+
+const SECRET = process.env.JWT_SECRET || 'changeme';
+
+const users = [
+  { id: 1, username: 'admin', password: 'password', role: 'admin' },
+  { id: 2, username: 'user', password: 'password', role: 'user' }
+];
+
+app.post('/auth/login', (req, res) => {
+  const { username, password } = req.body;
+  const user = users.find(u => u.username === username && u.password === password);
+  if (!user) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+  const token = jwt.sign({ id: user.id, role: user.role }, SECRET, { expiresIn: '1h' });
+  res.json({ token });
+});
+
+app.get('/api/hello', (req, res) => {
+  res.json({ message: 'Hello World' });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "server",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "nodemon index.js",
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.1"
+  }
+}

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Form Builder</title>
+  <script type="module" src="/src/main.jsx"></script>
+</head>
+<body class="bg-gray-100">
+  <div id="root"></div>
+</body>
+</html>

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.3.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.3.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0"
+  }
+}

--- a/packages/web/postcss.config.js
+++ b/packages/web/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/packages/web/src/App.jsx
+++ b/packages/web/src/App.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function App() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Form Builder</h1>
+      <p className="mt-2">Project setup successful.</p>
+    </div>
+  );
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/packages/web/src/main.jsx
+++ b/packages/web/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/packages/web/tailwind.config.js
+++ b/packages/web/tailwind.config.js
@@ -1,0 +1,10 @@
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- start monorepo with npm workspaces
- scaffold Express backend with JWT auth
- add basic React frontend (Vite + Tailwind)
- add example SQL schema
- add CI workflow and environment example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840529e467c8328bb01c3a825417b2c